### PR TITLE
For nested loops guard fix

### DIFF
--- a/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.cpp
+++ b/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.cpp
@@ -422,7 +422,7 @@ public:
 
         if (GuardLimitValue.hasValue()) {
           if (LoopLimit && *LoopLimit != 0) {
-            GuardLimit = double((*GuardLimitValue + 1)) / double(*LoopLimit + 1) * *LoopLimit;
+            GuardLimit = ((*GuardLimitValue + 1) * *LoopLimit) / (*LoopLimit + 1);
           }
           else {
             GuardLimit = *GuardLimitValue;

--- a/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.cpp
+++ b/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.cpp
@@ -241,18 +241,22 @@ void fixLimitForSpecialCases(int64_t &limitedValue, const BinaryOperator *condOp
   }
 }
 
+int sgn(int val) {
+    return (0 < val) - (val < 0);
+}
+
 Optional<int64_t> calculateLoopGuardLimit(std::string op, int64_t initVal, int64_t condVal, int64_t incVal, bool condContainsEq) {
-  if (op.find("+") != std::string::npos && incVal != 0) {
+  if (op.find("+") != std::string::npos && incVal != 0 && sgn(condVal - initVal) == sgn(incVal)) {
     return std::ceil(static_cast<double>(condVal - initVal + (condContainsEq ? 1 : 0)) / static_cast<double>(incVal));
   }
-  if (op.find("-") != std::string::npos && incVal != 0) {
+  if (op.find("-") != std::string::npos && incVal != 0 && sgn(initVal - condVal) == sgn(incVal)) {
     return std::ceil(static_cast<double>(initVal - condVal + (condContainsEq ? 1 : 0)) / static_cast<double>(incVal));
   }
-  if (op.find("*") != std::string::npos && initVal != 0) { //this is a solution to eq: (a^x)*b = c
+  if (op.find("*") != std::string::npos && initVal != 0 && incVal != 1) { //this is a solution to eq: (a^x)*b = c
     int64_t x = std::floor(std::log((condVal - initVal + (condContainsEq ? 1 : 0))/initVal) / std::log(incVal)) + 1;
     return x;
   }
-  if (op.find("/") != std::string::npos && incVal != 0) {
+  if (op.find("/") != std::string::npos && incVal > 1) {
     if (condContainsEq) {
       --condVal;
     }

--- a/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.h
+++ b/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.h
@@ -21,7 +21,23 @@ namespace hooks {
 /// for (int i = 0; GUARD(3), i < 3; ++i)
 ///
 /// This is the only way to satisfy the guard rule when using a
-/// for-loop in C.
+/// for-loop in C. Guard should be placed either in a for loop
+/// condition or as a first call in loop body, e.g.
+///
+/// for(int i = 0; i < 3; ++i) {
+///   GUARD(3);
+/// }
+/// 
+/// In case of nested loops, the guard limit value should be 
+/// multiplied by a number of iterations in each loop, e.g.
+///
+/// for(int i = 0; GUARD(3), i < 3; ++i) {
+///   for (int j = 0; GUARD(17), j < 5; ++j)
+/// }
+/// 
+/// (most descendant loop iterations + 1) * (each parent loops iterations + 0) - 1
+///
+/// 
 class GuardInForCheck : public ClangTidyCheck {
 public:
   GuardInForCheck(StringRef Name, ClangTidyContext *Context)

--- a/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.h
+++ b/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.h
@@ -36,6 +36,30 @@ namespace hooks {
 /// 
 /// (most descendant loop iterations + 1) * (each parent loops iterations) - 1
 ///
+/// This checker will also calculate the GUARD limit and show a hint with proposed value 
+/// next to a warning. Calculation is based on for loop parameters: init value, condition 
+/// limit and loop increment. There are few requirements for the calculation to be 
+/// performed correctly:
+/// - loop index must be initialized inside the init part of the loop (however the 
+///   variable can be declared outside of the for loop)
+/// - there must be a proper condition limit set in the condition part of the loop, or a 
+///   GUARD call must placed there (in which case the GUARD limit calculation of nested 
+///   loops will be based on it)
+/// - there must be a proper increment defined (e.g. i++, i += 2, i = i * 2)
+/// - loop condition can contain multiple logical expressions, like "i < 2 && k > 3" or "k < 3, i < 2"
+///   however in case of the "," operator it is not verified whether the part with loop 
+///   index is on the right hand side of the operator
+/// - there can be more than one variable initialized in the init part of the for loop
+/// - in case of nested for loops GUARD limit is calculated only from parent for loops 
+///   parameters (or existing GUARD calls), any other statements (if, while, etc.) are ignored
+/// - if GUARD call is placed in a parent for loop it's value is used to calculate 
+///   the GUARD limit for nested loops - it will not be check whether the GUARD value 
+///   placed by the programmer is correct
+/// - for loop init, condition limit and increment values must be either integer literals or
+///   const int variables, so that their values can be evaluated during compile time - they 
+///   cannot be expressions like i = 5 + 4, etc.
+
+
 class GuardInForCheck : public ClangTidyCheck {
 public:
   GuardInForCheck(StringRef Name, ClangTidyContext *Context)

--- a/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.h
+++ b/clang-tools-extra/clang-tidy/hooks/GuardInForCheck.h
@@ -20,9 +20,8 @@ namespace hooks {
 /// #define GUARD(maxiter) _g(__LINE__, (maxiter)+1)
 /// for (int i = 0; GUARD(3), i < 3; ++i)
 ///
-/// This is the only way to satisfy the guard rule when using a
-/// for-loop in C. Guard should be placed either in a for loop
-/// condition or as a first call in loop body, e.g.
+/// To satisfy the guard rule when using a for-loop in C guard should be 
+/// place either in the condition part of the loop, or as a first call in loop body, e.g.
 ///
 /// for(int i = 0; i < 3; ++i) {
 ///   GUARD(3);
@@ -35,9 +34,8 @@ namespace hooks {
 ///   for (int j = 0; GUARD(17), j < 5; ++j)
 /// }
 /// 
-/// (most descendant loop iterations + 1) * (each parent loops iterations + 0) - 1
+/// (most descendant loop iterations + 1) * (each parent loops iterations) - 1
 ///
-/// 
 class GuardInForCheck : public ClangTidyCheck {
 public:
   GuardInForCheck(StringRef Name, ClangTidyContext *Context)

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -29,19 +29,38 @@ int64_t hook(int64_t reserved)
 
     // ...but infinite looping certainly isn't allowed
     for (;;);
-// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: for loop does not call '_g' [hooks-guard-in-for]
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
 
     for (int i = 0; 2 > i; ++i)
-// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call '_g' [hooks-guard-in-for]
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
     {
-	trace_num("four", 3, i);
+	trace_num("four", 4, i);
     }
 
     int i;
     for (i = 1; i < 3; ++i)
-// CHECK-MESSAGES: :[[@LINE-1]]:17: warning: for loop does not call '_g' [hooks-guard-in-for]
+// CHECK-MESSAGES: :[[@LINE-1]]:17: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
     {
-	trace_num("five", 3, i);
+	trace_num("five", 4, i);
+    }
+
+    for (int i = 0; i < 1; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+    {
+        trace_num("six", 3, i);
+        for (int j = 0; j < 2; ++j)
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+        {
+            trace_num("seven", 5, j);
+            for (int k = 0; GUARD(4), k < 3; ++k)
+            {
+                for (int w = 0; w < 4; ++w)
+// CHECK-MESSAGES: :[[@LINE-1]]:33: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+                {
+                    trace_num("eight", 5, w);
+                }
+            }
+        }
     }
 
     return 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -261,5 +261,15 @@ int64_t hook(int64_t reserved)
         }
     }
 
+    const a = 1;
+    const b = 5;
+    const c = 2;
+    for (int i = a; i < b; i *= c)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(3)
+    {
+        trace_num("twenty six", 10, i);
+    }
+
     return 0;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -202,7 +202,15 @@ int64_t hook(int64_t reserved)
 // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
 // CHECK-FIXES: GUARD(4)
     {
-
+        trace_num("twenty", 6, i);
+    }
+    
+    int j = 0;
+    for (int i = 0; k < 2, i < 4 && j < 3; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:28: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(4)
+    {
+        trace_num("twenty one", 10, i);
     }
 
     return 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -213,26 +213,51 @@ int64_t hook(int64_t reserved)
         trace_num("twenty one", 10, i);
     }
 
-    for (int i = 0; GUARD(reserved), i < 10; ++i)
-// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: 'GUARD' calls can only have const integers or literals as an argument [hooks-guard-in-for]
+    const int x = 5;
+    for (int i = 0; GUARD(x), i < 10; ++i)
     {
         trace_num("twenty two", 10, i);
     }
 
-    const int x = 5;
-    for (int i = 0; GUARD(x), i < 10; ++i)
-    {
-        trace_num("twenty three", 12, i);
-    }
-
     for (int i = 0; GUARD(reserved), i < 10; ++i)
-// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: 'GUARD' calls can only have const integers or literals as an argument [hooks-guard-in-for]
     {
         for (int j = 0; j < 2; ++j)
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
 // CHECK-FIXES: GUARD(29)
         {
-            trace_num("twenty four", 11, j);
+            trace_num("twenty three", 12, j);
+        }
+    }
+
+    for (int i = 0; GUARD(10), i < 10; ++i) 
+    {
+        if (!i) 
+        {
+            for (int j = 0; GUARD(2), j < 2; ++j) 
+            {
+                for (int k = 0; k < 5; ++k) 
+// CHECK-MESSAGES: :[[@LINE-1]]:33: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(11)
+                {
+                    trace_num("twenty four", 11, k);
+                }
+            }
+        }
+    }
+
+    for (int i = 0; GUARD(10), i < 10; ++i) 
+    {
+        if (i % 2)
+        {
+            for (int j = 0; GUARD(29), j < 5; ++j) 
+            {
+                for (int k = 0; k < 10; ++k) 
+// CHECK-MESSAGES: :[[@LINE-1]]:33: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(274)
+                {
+                    trace_num("twenty five", 11, k);
+                }
+            }
         }
     }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -137,5 +137,73 @@ int64_t hook(int64_t reserved)
         trace_num("thirteen", 8, j);
     }
 
+    for (int i = 0; i < 5; ++i)
+    {
+        GUARD(5);
+        for (int j = 0; j < 3; ++j)
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(19)
+        {
+            trace_num("fourteen", 8, j);
+        }
+    }
+
+    for (int i = 0; i < 5; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(5)
+    {
+        for (int j = 0; GUARD(19), j < 3; ++j)
+        {
+            trace_num("fifteen", 7, j);
+        }
+    }
+
+    for (int i = 0; i < 5; ++i) 
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(5)
+    {
+        for (int j = 0; j < 3; ++j)
+        {
+            GUARD(19);
+            trace_num("sixteen", 7, j);
+        }
+    }
+
+    for (int i = 0; i < 10; i += 2)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(5)
+    {
+        trace_num("sixteen", 7, i);
+    }
+
+    for (int i = 1; 10 > i; i *= 2)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(4)
+    {
+        trace_num("seventeen", 9, i);
+    }
+
+    for (int i = 10; i >= 0; i = i - 2)
+// CHECK-MESSAGES: :[[@LINE-1]]:22: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(6)
+    {
+        trace_num("eighteen", 8, i);
+    }
+
+    for (int i = 10; i > 0; i = i / 2)
+// CHECK-MESSAGES: :[[@LINE-1]]:22: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(4)
+    {
+        trace_num("nineteen", 8, i);
+    }
+
+    int k = 0;
+    for (int i = 0; k < 2, i < 4; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:28: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(4)
+    {
+
+    }
+
     return 0;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s hooks-guard-in-for %t
 
-#include <stdint.h>
+#include "stdint.h"
 
 extern int32_t _g (uint32_t id, uint32_t maxiter);
 extern int64_t trace_num (const char *read_ptr, uint32_t read_len, int64_t number);
@@ -30,9 +30,11 @@ int64_t hook(int64_t reserved)
     // ...but infinite looping certainly isn't allowed
     for (;;);
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-MESSAGES-NOT: GUARD
 
     for (int i = 0; 2 > i; ++i)
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(2)
     {
 	trace_num("four", 4, i);
     }
@@ -40,27 +42,99 @@ int64_t hook(int64_t reserved)
     int i;
     for (i = 1; i < 3; ++i)
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(2)
     {
 	trace_num("five", 4, i);
     }
 
     for (int i = 0; i < 1; ++i)
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(1)
     {
-        trace_num("six", 3, i);
         for (int j = 0; j < 2; ++j)
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(2)
         {
-            trace_num("seven", 5, j);
-            for (int k = 0; GUARD(4), k < 3; ++k)
+            for (int k = 0; GUARD(3), k < 3; ++k)
             {
                 for (int w = 0; w < 4; ++w)
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(29)
                 {
-                    trace_num("eight", 5, w);
+                    trace_num("six", 3, w);
                 }
             }
         }
+    }
+
+    for (int i = 0; i < 5; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(5)
+    {
+        while (1)
+        {
+            for (int j = 0; j < 3; ++j)
+// CHECK-MESSAGES: :[[@LINE-1]]:13: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-MESSAGES-NOT: GUARD
+            {
+                trace_num("seven", 5, j);
+            }
+        }
+    }
+
+    for (int i = 0; i < 5 + reserved; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-MESSAGES-NOT: GUARD
+    {
+        for (int j = 0; j < 3; ++j)
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-MESSAGES-NOT: GUARD
+            {
+                trace_num("eight", 5, j);
+            }
+    }
+
+    for (int i = 0; GUARD(5), i < 5 + reserved; ++i)
+    {
+        for (int j = 0; j < 3; ++j)
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(19)
+        {
+            trace_num("nine", 4, j);
+        }
+    }
+
+    for (int i = 0; i <= 5; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(6)
+    {
+        trace_num("ten", 3, i);
+    }
+
+    for (int i = 0; 5 != i; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(5)
+    {
+        for (int j = 0; j != 5; ++j)
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(29)
+        {
+            trace_num("eleven", 6, j);
+        }
+    }
+
+    for (int j = 5; j > 0; --j)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(5)
+    {
+        trace_num("twelve", 6, j);
+    }
+
+    for (int j = 5; 0 <= j; --j)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(6)
+    {
+        trace_num("thirteen", 8, j);
     }
 
     return 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -278,5 +278,24 @@ int64_t hook(int64_t reserved)
         trace_num("twenty seven", 12, i);
     }
 
+    for (int i = 0; i < 5; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(5)
+    {
+        if (i == 0)
+        {
+            for (int j = 0; j < 3; ++j)
+            {
+                GUARD(3);
+                for (int k = 0; k < 6; ++k) 
+// CHECK-MESSAGES: :[[@LINE-1]]:33: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(20)
+                {
+                    trace_num("twenty eight", 12, k);
+                }
+            }
+        }
+    }
+
     return 0;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -55,7 +55,7 @@ int64_t hook(int64_t reserved)
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
 // CHECK-FIXES: GUARD(2)
         {
-            for (int k = 0; GUARD(3), k < 3; ++k)
+            for (int k = 0; GUARD(7), k < 3; ++k)
             {
                 for (int w = 0; w < 4; ++w)
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: for loop does not call 'GUARD' [hooks-guard-in-for]

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -213,5 +213,28 @@ int64_t hook(int64_t reserved)
         trace_num("twenty one", 10, i);
     }
 
+    for (int i = 0; GUARD(reserved), i < 10; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: 'GUARD' calls can only have const integers or literals as an argument [hooks-guard-in-for]
+    {
+        trace_num("twenty two", 10, i);
+    }
+
+    const int x = 5;
+    for (int i = 0; GUARD(x), i < 10; ++i)
+    {
+        trace_num("twenty three", 12, i);
+    }
+
+    for (int i = 0; GUARD(reserved), i < 10; ++i)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: 'GUARD' calls can only have const integers or literals as an argument [hooks-guard-in-for]
+    {
+        for (int j = 0; j < 2; ++j)
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(29)
+        {
+            trace_num("twenty four", 11, j);
+        }
+    }
+
     return 0;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/hooks-guard-in-for.c
@@ -271,5 +271,12 @@ int64_t hook(int64_t reserved)
         trace_num("twenty six", 10, i);
     }
 
+    for (int i = 0; i > -5; i = i + -1)
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: for loop does not call 'GUARD' [hooks-guard-in-for]
+// CHECK-FIXES: GUARD(5)
+    {
+        trace_num("twenty seven", 12, i);
+    }
+
     return 0;
 }


### PR DESCRIPTION
Nested loops up to 10 nesting level have now properly calculated GUARD limit. If any of the nested loops doesn't have init value and/or condition limit (so GUARD limit cannot be calculated) only a warning is displayed, without hint. 